### PR TITLE
Set window level to be on top

### DIFF
--- a/DiskStatus/SettingsWindow/SettingsWindow.swift
+++ b/DiskStatus/SettingsWindow/SettingsWindow.swift
@@ -39,6 +39,7 @@ class SettingsWindow: NSWindowController, NSWindowDelegate {
         
         self.window?.center()
         self.window?.makeKeyAndOrderFront(nil)
+        self.window?.level = Int(CGWindowLevelForKey(.floatingWindow))
         NSApp.activate(ignoringOtherApps: true)
     }
     


### PR DESCRIPTION
closes #1 

# Changes
- Set window level to `CGWindowLevel.floatingWindow` to make it appear on top